### PR TITLE
Fix web process not binding to the port on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,6 @@
   "main": "index.jsx",
   "author": "Armen Zambrano G. <armenzg@mozilla.com>",
   "repository": "git@github.com:mozilla/firefox-code-coverage-frontend.git",
-  "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=5.0.0",
-    "yarn": ">=1.0.0"
-  },
   "scripts": {
     "build": "neutrino build",
     "start": "neutrino start",


### PR DESCRIPTION
Heroku builds properly the switch to Neutrino, however, for some reason the app won't start:

> Feb 09 05:45:35 firefox-code-coverage heroku/web.1: Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch

I've read that letting Heroku choose the LTS versions of node and npm helps with this issue.
Removing the `engines` entry allows Heroku to choose the LTS versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/114)
<!-- Reviewable:end -->
