### PR TITLE
Issue #107 - Changeset in main page to link to Hg and coverage summary to navigate to the diff viewer

### DIFF
--- a/src/components/summaryviewer.js
+++ b/src/components/summaryviewer.js
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import React, { Component } from 'react';
 import ReactInterval from 'react-interval';
 
@@ -9,15 +8,24 @@ import { arrayToMap, csetWithCcovData, mapToArray } from '../utils/data';
 import bzIcon from '../static/bugzilla.png';
 
 const ChangesetInfo = ({ changeset }) => {
-  const { author, desc, hidden, bzUrl, linkify, node, summary, summaryClassName } = changeset;
+  const { author, desc, hidden, bzUrl, node, summary, summaryClassName } = changeset;
+  const hgUrl = changeset.coverage.hgRev;
+  const handleClick = (e) => {
+    if (e.target.tagName.toLowerCase() === 'td') {
+      window.open(`/#/changeset/${node}`, '_blank');
+    } else {
+      e.stopPropagation();
+    }
+  };
   // XXX: For author remove the email address
   // XXX: For desc display only the first line
   return (
-    <tr className={(hidden) ? 'hidden-changeset' : 'changeset'}>
+    <tr className={(hidden) ? 'hidden-changeset' : 'changeset'} onClick={e => handleClick(e)}>
       <td className="changeset-author">{author.substring(0, 22)}</td>
-      <td className="changeset-node-id">{(linkify) ?
-        <Link to={`/changeset/${node}`}>{node.substring(0, 12)}</Link>
-        : <span>{node.substring(0, 12)}</span>}
+      <td className="changeset-hg">
+        {(hgUrl) ?
+          <a href={hgUrl} target="_blank">{node.substring(0, 12)}</a>
+          : <span>{node.substring(0, 12)}</span>}
       </td>
       <td className="changeset-description">
         {desc.substring(0, 40).padEnd(40)}

--- a/src/style.css
+++ b/src/style.css
@@ -149,6 +149,10 @@ pre { margin: 0; }
 .hidden-changeset {
 	display: none
 }
+.changeset:hover td {
+	cursor: pointer;
+	background-color: #cce6ff;
+}
 .changeset-description {
 	display: flex;
 	flex-direction: row;

--- a/src/style.css
+++ b/src/style.css
@@ -155,7 +155,6 @@ pre { margin: 0; }
 }
 .changeset-description {
 	display: flex;
-	flex-direction: row;
 	justify-content: space-between;
 }
 .changeset-summary {


### PR DESCRIPTION
Changeset column links now redirect to Hg and Coverage Diff column created to access DiffViewer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/121)
<!-- Reviewable:end -->
