### PR TITLE
Issue #120: Bad coverage calculation

### DIFF
--- a/src/components/diffviewer.js
+++ b/src/components/diffviewer.js
@@ -197,7 +197,7 @@ const DiffLine = ({ change, fileDiffs, id }) => {
     // Added line - <blank> | <new line number>
     if (fileDiffs) {
       try {
-        const coverage = fileDiffs[c.ln];
+        const coverage = fileDiffs.lines[c.ln];
         if (coverage === 'Y') {
           rowClass = 'hit';
         } else if (coverage === '?') {


### PR DESCRIPTION
Fixes #120 
Previously coverage was determined by looking at the fileDiffs object when line coverage information was actually in fileDiffs.lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/125)
<!-- Reviewable:end -->
