### PR TITLE
Issue #115: FileViewer: Accept any length revision number

### DIFF
--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -49,6 +49,7 @@ export default class FileViewerContainer extends Component {
           } else {
             this.setState({ appErr: `${error.name}: ${error.message}` });
           }
+          throw e;
         });
     } catch (error) {
       this.setState({ appErr: `${error.name}: ${error.message}` });

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -42,7 +42,14 @@ export default class FileViewerContainer extends Component {
     };
     // Fetch source code and coverage in parallel
     try {
-      Promise.all([fileSource(), coverageData()]);
+      Promise.all([fileSource(), coverageData()])
+        .catch((e) => {
+          if ((e instanceof RangeError) && (e.message === 'Revision number too short')) {
+            this.setState({ appErr: 'Revision number is too short. Unable to fetch tests.' });
+          } else {
+            this.setState({ appErr: `${error.name}: ${error.message}` });
+          }
+        });
     } catch (error) {
       this.setState({ appErr: `${error.name}: ${error.message}` });
     }
@@ -68,13 +75,14 @@ export default class FileViewerContainer extends Component {
   }
 
   render() {
-    const { parsedFile, coverage, selectedLine } = this.state;
+    const { parsedFile, coverage, selectedLine, appErr } = this.state;
 
     return (
       <div>
         <div className="file-view">
           <FileViewerMeta {...this.state} />
-          { (parsedFile) && <FileViewer {...this.state} onLineClick={this.setSelectedLine} /> }
+          { !appErr && (parsedFile) &&
+            <FileViewer {...this.state} onLineClick={this.setSelectedLine} /> }
         </div>
         <TestsSideViewer
           coverage={coverage}

--- a/src/settings.js
+++ b/src/settings.js
@@ -18,4 +18,4 @@ export const PENDING = 'Pending';
 
 export const LOADING = 'Loading...';
 
-export const MIN_REVISION_LENGTH = 12;
+export const MIN_REVISION_LENGTH = 5;

--- a/src/settings.js
+++ b/src/settings.js
@@ -17,3 +17,5 @@ export const SETTINGS = {
 export const PENDING = 'Pending';
 
 export const LOADING = 'Loading...';
+
+export const MIN_REVISION_LENGTH = 12;

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { PENDING, SETTINGS } from '../settings';
+import { MIN_REVISION_LENGTH, PENDING, SETTINGS } from '../settings';
 import * as FetchAPI from '../utils/fetch_data';
 
 export const arrayToMap = (csets) => {
@@ -198,12 +198,15 @@ export const rawFile = async (revision, path, repoPath) => {
 
 export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
   try {
+    if (revision.length < MIN_REVISION_LENGTH) {
+      throw new Error(`Revision number must be at least ${MIN_REVISION_LENGTH} digits long`);
+    }
     const res = await FetchAPI.queryActiveData({
       from: 'coverage',
       where: {
         and: [
           { eq: { 'source.file.name': path } },
-          { eq: { 'repo.changeset.id12': revision } },
+          { prefix: { 'repo.changeset.id': revision } },
           { eq: { 'repo.branch.name': repoPath } },
         ],
       },

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -218,7 +218,7 @@ export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
     }
     return res.json();
   } catch (e) {
-      console.error(`Failed to fetch data for revision: ${revision}, path: ${path}\n${e}`);
-      throw e;
+    console.error(`Failed to fetch data for revision: ${revision}, path: ${path}\n${e}`);
+    throw e;
   }
 };

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -199,7 +199,7 @@ export const rawFile = async (revision, path, repoPath) => {
 export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
   try {
     if (revision.length < MIN_REVISION_LENGTH) {
-      throw new Error(`Revision number must be at least ${MIN_REVISION_LENGTH} digits long`);
+      throw new RangeError('Revision number too short');
     }
     const res = await FetchAPI.queryActiveData({
       from: 'coverage',
@@ -218,7 +218,10 @@ export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
     }
     return res.json();
   } catch (e) {
-    console.error(`Failed to fetch data for revision: ${revision}, path: ${path}\n${e}`);
-    throw new Error('Failed to get coverage from ActiveData');
+    if ((e instanceof RangeError) && (e.message === 'Revision number too short')) {
+      throw e;
+    } else {
+      throw new Error('Failed to get coverage from ActiveData');
+    }
   }
 };

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -218,10 +218,7 @@ export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
     }
     return res.json();
   } catch (e) {
-    if ((e instanceof RangeError) && (e.message === 'Revision number too short')) {
+      console.error(`Failed to fetch data for revision: ${revision}, path: ${path}\n${e}`);
       throw e;
-    } else {
-      throw new Error('Failed to get coverage from ActiveData');
-    }
   }
 };


### PR DESCRIPTION
#115 FileViewer should now load the Covered Tests sidebar correctly for revision numbers longer than 12 letters. An extra truncation was added to the revision number when querying ActiveData.

This shows the tests correctly
https://firefox-code-coverage.herokuapp.com/#/file?revision=fdd1a0082c71&path=js/src/wasm/WasmValidate.cpp

This fails to load tests from ActiveData currently, but loads correctly on my local
https://firefox-code-coverage.herokuapp.com/#/file?revision=fdd1a0082c71673239fc2f3a6a93de889c07a1be&path=js/src/wasm/WasmValidate.cpp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/146)
<!-- Reviewable:end -->
