### PR TITLE
WIP: Issue #72 - Lines with no coverage information are marked as miss

### DIFF
--- a/src/components/diffviewer.js
+++ b/src/components/diffviewer.js
@@ -208,10 +208,10 @@ const DiffLine = ({ change, fileDiffs, id }) => {
         const coverage = fileDiffs.lines[c.ln];
         if (coverage === 'Y') {
           rowClass = 'hit';
-        } else if (coverage === '?') {
-          rowClass = 'nolinechange';
-        } else {
+        } else if (coverage === 'N') {
           rowClass = 'miss';
+        } else {
+          rowClass = 'nolinechange';
         }
       } catch (e) {
         console.log(e);


### PR DESCRIPTION
Initially marking lines as 'nolinechange' if coverage information is not present. Checking for more changesets/cases and how to handle when missing lines should be marked as green: https://firefox-code-coverage.herokuapp.com/#/changeset/ddb98ad66aa0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/151)
<!-- Reviewable:end -->
