### PR TITLE
Fix: The DiffViewer should not fail if the coverage data for a changeset is PENDING

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -5,11 +5,7 @@ module.exports = {
       {
         eslint: {
           rules: {
-            "comma-dangle": "off",
-            "indent": "off",
             "no-console": "off",
-            "no-undef": "off",
-            "no-underscore-dangle": "off",
             "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
             "react/prop-types": "off",
           }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -23,7 +23,8 @@ const AppDisclaimer = () => (
       <p>NOTE: This app is in beta state.</p>
       <p>There are some core issues with regards to coverage collection. These are
         explained in the project&apos;s&nbsp;
-        <a href={`${REPO}/blob/master/README.md#disclaimers`}>readme</a>.</p>
+      <a href={`${REPO}/blob/master/README.md#disclaimers`}>readme</a>.
+      </p>
     </div>
     <div>
       Project information: <a href={REPO}>Frontend repository</a>&nbsp;

--- a/src/components/diffviewer.js
+++ b/src/components/diffviewer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import * as _ from 'lodash';
+import { orderBy } from 'lodash';
 
 import { csetWithCcovData } from '../utils/data';
 import hash from '../utils/hash';
@@ -80,7 +80,7 @@ const sortByPercent = (parsedDiff, coverage) => {
     const cov = p;
     cov.percent = (coverage.diffs[p.from]) ? coverage.diffs[p.from].percent : 0;
   });
-  const sortedDiffs = _.orderBy(parsedDiff, ({ percent }) => percent || 0, ['desc']);
+  const sortedDiffs = orderBy(parsedDiff, ({ percent }) => percent || 0, ['desc']);
   return sortedDiffs;
 };
 

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -47,7 +47,7 @@ export default class FileViewerContainer extends Component {
           if ((e instanceof RangeError) && (e.message === 'Revision number too short')) {
             this.setState({ appErr: 'Revision number is too short. Unable to fetch tests.' });
           } else {
-            this.setState({ appErr: `${error.name}: ${error.message}` });
+            this.setState({ appErr: `${e.name}: ${e.message}` });
           }
           throw e;
         });
@@ -76,7 +76,9 @@ export default class FileViewerContainer extends Component {
   }
 
   render() {
-    const { parsedFile, coverage, selectedLine, appErr } = this.state;
+    const {
+      parsedFile, coverage, selectedLine, appErr,
+    } = this.state;
 
     return (
       <div>
@@ -95,7 +97,9 @@ export default class FileViewerContainer extends Component {
 }
 
 // This component renders each line of the file with its line number
-const FileViewer = ({ parsedFile, coverage, selectedLine, onLineClick }) => (
+const FileViewer = ({
+  parsedFile, coverage, selectedLine, onLineClick,
+}) => (
   <table className="file-view-table">
     <tbody>
       {parsedFile.map((text, lineNumber) => {
@@ -115,7 +119,9 @@ const FileViewer = ({ parsedFile, coverage, selectedLine, onLineClick }) => (
   </table>
 );
 
-const Line = ({ lineNumber, text, coverage, selectedLine, onLineClick }) => {
+const Line = ({
+  lineNumber, text, coverage, selectedLine, onLineClick,
+}) => {
   const handleOnClick = () => {
     onLineClick(lineNumber);
   };
@@ -147,7 +153,9 @@ const Line = ({ lineNumber, text, coverage, selectedLine, onLineClick }) => {
 };
 
 // This component contains metadata of the file
-const FileViewerMeta = ({ revision, path, appErr, parsedFile, coverage }) => {
+const FileViewerMeta = ({
+  revision, path, appErr, parsedFile, coverage,
+}) => {
   const showStatus = (label, data) => (
     <li className="file-meta-li">
       {label}: {(data) ? HEAVY_CHECKMARK : HORIZONTAL_ELLIPSIS}

--- a/src/components/fileviewercov.js
+++ b/src/components/fileviewercov.js
@@ -24,6 +24,7 @@ export class TestsSideViewer extends Component {
       <ul className="test-viewer-ul">
         {tests.map((test, row) => (
           <Test
+            // eslint-disable-next-line no-underscore-dangle
             key={test._id}
             row={row}
             test={test}
@@ -71,7 +72,9 @@ export class TestsSideViewer extends Component {
 }
 
 // Test list item in the TestsSideViewer
-const Test = ({ row, test, expand, handleTestOnExpand }) => (
+const Test = ({
+  row, test, expand, handleTestOnExpand,
+}) => (
   <li>
     <button className="test-switch" onClick={() => handleTestOnExpand(row)}>
       <span className={`test-symbol ${expand}`}>{TRIANGULAR_BULLET}</span>

--- a/src/components/summaryviewer.js
+++ b/src/components/summaryviewer.js
@@ -12,7 +12,9 @@ const CACHETIME = 86400; // 24 hours to seconds
 const MSTOS = 1000; // ms to s conversion
 
 const ChangesetInfo = ({ changeset }) => {
-  const { author, desc, hidden, bzUrl, node, summary, summaryClassName } = changeset;
+  const {
+    author, desc, hidden, bzUrl, node, summary, summaryClassName,
+  } = changeset;
   const hgUrl = changeset.coverage.hgRev;
   const handleClick = (e) => {
     if (e.target.tagName.toLowerCase() === 'td') {
@@ -42,8 +44,8 @@ const ChangesetInfo = ({ changeset }) => {
 };
 
 const ChangesetsViewer = ({ changesets }) => (
-  (changesets.length > 0) ?
-    (<table className="changeset-viewer">
+  (changesets.length > 0) ? (
+    <table className="changeset-viewer">
       <tbody>
         <tr>
           <th>Author</th>
@@ -62,8 +64,8 @@ const ChangesetsViewer = ({ changesets }) => (
 );
 
 const PollingStatus = ({ pollingEnabled }) => (
-  (pollingEnabled) ?
-    (<div className="polling-status"> {pollingEnabled}
+  (pollingEnabled) ? (
+    <div className="polling-status"> {pollingEnabled}
       Some changesets are still being processed and we are actively
       polling them until we get a result.
     </div>) : (null)
@@ -175,13 +177,12 @@ export default class ChangesetsViewerContainer extends Component {
     console.log('Determine if we need to poll csets w/o coverage data...');
     try {
       let newCsets = mapToArray(changesets);
-      newCsets = await Promise.all(
-        newCsets.map((c) => {
-          if (c.summary !== PENDING) {
-            return c;
-          }
-          return csetWithCcovData(c);
-        }));
+      newCsets = await Promise.all(newCsets.map((c) => {
+        if (c.summary !== PENDING) {
+          return c;
+        }
+        return csetWithCcovData(c);
+      }));
       const count = newCsets.filter(c => c.summary === PENDING).length;
       const csetsMap = arrayToMap(newCsets);
       if (count === 0) {
@@ -196,7 +197,10 @@ export default class ChangesetsViewerContainer extends Component {
   }
 
   render() {
-    const { changesets, pollingEnabled, errorMessage, timeout } = this.state;
+    const {
+      changesets, pollingEnabled, errorMessage, timeout,
+    } = this.state;
+
     if (errorMessage) {
       return (<div className="error-message">{errorMessage}</div>);
     }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import { uniq } from 'lodash';
 import { MIN_REVISION_LENGTH, PENDING, SETTINGS } from '../settings';
 import * as FetchAPI from '../utils/fetch_data';
 
@@ -53,7 +53,7 @@ export const fileRevisionCoverageSummary = (coverage) => {
       s.testsPerHitLine[line].push(c);
     });
   });
-  s.coveredLines = _.uniq(s.coveredLines);
+  s.coveredLines = uniq(s.coveredLines);
   // get uncovered lines
   coverage.forEach((c) => {
     c.source.file.uncovered.forEach((line) => {
@@ -62,7 +62,7 @@ export const fileRevisionCoverageSummary = (coverage) => {
       }
     });
   });
-  s.uncoveredLines = _.uniq(s.uncoveredLines);
+  s.uncoveredLines = uniq(s.uncoveredLines);
   // calculate line coverage stats
   s.numCovLines = s.coveredLines.length;
   s.numUncovLines = s.uncoveredLines.length;


### PR DESCRIPTION
Normally, from the SummaryViewer you should not be able to get to the DiffViewer since
there's no link to navigate to it.

However, people clicking on links from GitHub issues can reach the DiffViewer, thus,
failing because there `coverage` object contains a summary property rather than
being undefined.

This change shows an error message to the user letting them know that they should
try again later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/152)
<!-- Reviewable:end -->
