### PR TITLE
Added coverage color legends

### DIFF
--- a/src/components/coverageMeta.jsx
+++ b/src/components/coverageMeta.jsx
@@ -27,6 +27,13 @@ const CoverageMeta = ({
         </div>
       </div>
     }
+    <div className="coverage-meta-row">
+      <ul className="coverage-legend-ul">
+        <li><span className="hit coverage-color-legend" /> Covered</li>
+        <li><span className="miss coverage-color-legend" /> Uncovered</li>
+        <li><span className="nocovchange coverage-color-legend" /> Unchanged line</li>
+      </ul>
+    </div>
   </div>
 );
 

--- a/src/components/coverageMeta.jsx
+++ b/src/components/coverageMeta.jsx
@@ -28,7 +28,7 @@ const CoverageMeta = ({
       </div>
     }
     <div className="coverage-meta-row">
-      <ul className="coverage-legend-ul">
+      <ul className="coverage-legend">
         <li><span className="hit coverage-color-legend" /> Covered</li>
         <li><span className="miss coverage-color-legend" /> Uncovered</li>
         <li><span className="nocovchange coverage-color-legend" /> Unchanged line</li>

--- a/src/style.css
+++ b/src/style.css
@@ -388,7 +388,7 @@ span.tests {
 	height: 14px;
 }
 
-.coverage-legend-ul{
+ul.coverage-legend{
 	list-style: none;
 	padding: 0;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -379,3 +379,16 @@ span.tests {
 	right: 0;
 	border: 0;
 }
+
+/* placing coverage color legends in DiffViewer*/
+.coverage-color-legend{
+	border: solid 1px black;
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+}
+
+.coverage-legend-ul{
+	list-style: none;
+	padding: 0;
+}


### PR DESCRIPTION
Added code coverage color legends in DiffViewer page.
Fixes #66 
@gmierz please review it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/166)
<!-- Reviewable:end -->
