### PR TITLE
Correctly display white-space in bug descriptions.

### DIFF
--- a/src/components/coverageMeta.jsx
+++ b/src/components/coverageMeta.jsx
@@ -23,7 +23,7 @@ const CoverageMeta = ({
       <div className="coverage-meta-row">
         <div style={{ display: 'flex' }}>
           <BugzillaIconLink description={changeset.desc} />
-          <span style={{ verticalAlign: 'top' }}>{changeset.desc}</span>
+          <span style={{ verticalAlign: 'top', whiteSpace: 'pre' }}>{changeset.desc}</span>
         </div>
       </div>
     }


### PR DESCRIPTION
By default, HTML elements ignore and white-space characters like line breaks, causing bug descriptions to show up in a single, unbroken line. Adding the attribute `white-space: pre` fixes that.

## Before

![pre-before](https://user-images.githubusercontent.com/599268/38990635-5ca61296-43db-11e8-8f0a-b07224bc9773.png)

## After

![pre-after](https://user-images.githubusercontent.com/599268/38990536-f33a24a0-43da-11e8-8b06-03e2c0e52e0d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/167)
<!-- Reviewable:end -->
