### PR TITLE
Show patch author in DiffViewer.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ we would like to lay down some principles and steps that will make contributing 
 git checkout master
 // Set up the upstream remote in the 'Getting started' section
 git pull upstream master 
-git checkout your_feature_branch_name
+git checkout -b your_feature_branch_name
 // This command might show code conflicts that you will have to resolve
 git rebase master
 ```

--- a/src/components/coverageMeta.jsx
+++ b/src/components/coverageMeta.jsx
@@ -1,6 +1,9 @@
 import BugzillaIconLink from './bugzillaIconLink';
 import { hgDiffUrl, pushlogUrl } from '../utils/hg';
 
+import dummyIcon from '../static/dummyIcon16x16.png';
+import eIcon from '../static/noun_205162_cc.png';
+
 const CoverageMeta = ({
   changeset, node, overallCoverage, summary,
 }) => (
@@ -19,6 +22,20 @@ const CoverageMeta = ({
         <a href={hgDiffUrl(node)} target="_blank">Hg Diff</a>
       </span>
     </div>
+    {changeset &&
+      <div className="coverage-meta-row">
+        <div>
+          {changeset.authorEmail ?
+            <a href={`mailto: ${changeset.authorEmail}`}>
+              <img className="eIcon" src={eIcon} alt="email icon" />
+            </a> : <img className="icon-substitute" src={dummyIcon} alt="placeholder icon" />
+          }
+          {changeset.authorName &&
+            <span className="changeset-eIcon-align">{changeset.authorName}</span>
+          }
+        </div>
+      </div>
+    }
     {changeset &&
       <div className="coverage-meta-row">
         <div>


### PR DESCRIPTION
I'm trying to add author information to the changeset coverage view, just like in the list of changesets on the front page.

However, for some reason, there is no `changeset.authorInfo` in the file I'm editing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/170)
<!-- Reviewable:end -->
