### PR TITLE
Update codecov.io and shipit URLs to point to production instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ From there you can navigate to the diff of each changeset
 and see the code coverage for added lines. It is very important to reiterate that it is code coverage for added lines and not for a specific file (as most code coverage viewers focus on).
 
 The data used in this UI is based on data submitted to
-[codecov.io](https://codecov.io/gh/marco-c/gecko-dev/commits).
+[codecov.io](https://codecov.io/gh/mozilla/gecko-dev/commits).
 
 # Planning and views
 This is document tracks the

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,12 +1,12 @@
 const settings = {
   ACTIVE_DATA: 'https://activedata.allizom.org',
-  BACKEND: 'https://uplift.shipit.mozilla-releng.net',
+  BACKEND: 'https://coverage.moz.tools',
   BZ_URL: 'https://bugzilla.mozilla.org',
   CACHE_CONFIG: {
     SECONDS_TO_EXPIRE: 1 * 60 * 60, // 1 hour
     ENABLED: process.env.ENABLE_CACHE === 'true' || process.env.NODE_ENV === 'production',
   },
-  CCOV_BACKEND: 'https://uplift.shipit.mozilla-releng.net',
+  CCOV_BACKEND: 'https://coverage.moz.tools',
   CODECOV_GECKO_DEV: 'https://codecov.io/gh/mozilla/gecko-dev',
   COVERAGE_THRESHOLDS: {
     low: {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,13 +1,13 @@
 const settings = {
   ACTIVE_DATA: 'https://activedata.allizom.org',
-  BACKEND: 'https://uplift.shipit.staging.mozilla-releng.net',
+  BACKEND: 'https://uplift.shipit.mozilla-releng.net',
   BZ_URL: 'https://bugzilla.mozilla.org',
   CACHE_CONFIG: {
     SECONDS_TO_EXPIRE: 1 * 60 * 60, // 1 hour
     ENABLED: process.env.ENABLE_CACHE === 'true' || process.env.NODE_ENV === 'production',
   },
-  CCOV_BACKEND: 'https://uplift.shipit.staging.mozilla-releng.net',
-  CODECOV_GECKO_DEV: 'https://codecov.io/gh/marco-c/gecko-dev',
+  CCOV_BACKEND: 'https://uplift.shipit.mozilla-releng.net',
+  CODECOV_GECKO_DEV: 'https://codecov.io/gh/mozilla/gecko-dev',
   COVERAGE_THRESHOLDS: {
     low: {
       threshold: 20,


### PR DESCRIPTION
Maybe we want to wait a couple of days before doing this, since there are just a few revisions on https://codecov.io/github/mozilla/gecko-dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/171)
<!-- Reviewable:end -->
