### PR TITLE
Calling getChangesetMeta() does not have author's email and name parsed

### DIFF
--- a/src/components/changesetInfo.jsx
+++ b/src/components/changesetInfo.jsx
@@ -14,18 +14,18 @@ const handleClick = (e, node) => {
 
 const ChangesetInfo = ({ changeset, summary, summaryClassName }) => {
   const {
-    authorInfo, desc, node,
+    authorEmail, authorName, desc, node,
   } = changeset;
 
   return (
     <tr className="changeset" onClick={e => handleClick(e, node)}>
       <td className="changeset-author">
-        {(authorInfo.email) ?
-          <a href={`mailto: ${authorInfo.email}`}>
+        {(authorEmail) ?
+          <a href={`mailto: ${authorEmail}`}>
             <img className="eIcon" src={eIcon} alt="email icon" />
           </a> : <img className="icon-substitute" src={dummyIcon} alt="placeholder icon" />
         }
-        <span className="changeset-eIcon-align">{authorInfo.name.substring(0, 60)}</span>
+        {(authorName) && <span className="changeset-eIcon-align">{authorName.substring(0, 60)}</span> }
       </td>
       <td className="changeset-hg">
         <a href={hgDiffUrl(node)} target="_blank">{node.substring(0, 12)}</a>

--- a/src/containers/diffViewer.jsx
+++ b/src/containers/diffViewer.jsx
@@ -43,7 +43,7 @@ export default class DiffViewerContainer extends Component {
   }
 
   async fetchSetChangesetMeta(node) {
-    const changeset = await (await getChangesetMeta(node)).json();
+    const changeset = await getChangesetMeta(node);
     this.setState({ changeset });
   }
 
@@ -66,7 +66,7 @@ export default class DiffViewerContainer extends Component {
 
   async fetchSetDiff(node) {
     try {
-      const text = await (await getDiff(node)).text();
+      const text = await getDiff(node);
       this.setState({ parsedDiff: parse(text) });
     } catch (e) {
       if ((e instanceof TypeError) && (e.message === 'Failed to fetch')) {


### PR DESCRIPTION
We were not initalizing a changeset's metadata the same way as when fetched
as part of a call to jsonPushes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/173)
<!-- Reviewable:end -->
