### PR TITLE
Issue #135 - Protect against backend data not being available

### DIFF
--- a/src/components/diffViewer.jsx
+++ b/src/components/diffViewer.jsx
@@ -2,7 +2,6 @@ import { Link } from 'react-router-dom';
 import DiffFile from './diffFile';
 import CoverageMeta from './coverageMeta';
 import CoverageFooter from './coverageFooter';
-import settings from '../settings';
 
 const DiffViewer = ({
   appError, changeset, coverage, parsedDiff,
@@ -12,7 +11,7 @@ const DiffViewer = ({
       <Link to="/" href="/">Return to main page</Link>
     </div>
     <span className="error_message">{appError}</span>
-    {(coverage && coverage.summary !== settings.STRINGS.PENDING) && (
+    {(coverage && coverage.show) && (
       <div>
         <CoverageMeta
           changeset={changeset}

--- a/src/containers/diffViewer.jsx
+++ b/src/containers/diffViewer.jsx
@@ -29,9 +29,11 @@ export default class DiffViewerContainer extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      appError: undefined,
-      coverage: undefined,
+      appError: '',
+      changeset: {},
+      coverage: {},
       parsedDiff: [],
+      supportedExtensions: [],
     };
   }
 
@@ -53,12 +55,14 @@ export default class DiffViewerContainer extends Component {
   async fetchSetCoverageData(node) {
     try {
       const coverage = await getChangesetCoverage(node);
+      let appError = '';
       if (coverage.summary === settings.STRINGS.PENDING) {
-        this.setState({
-          appError: 'The coverage data is still pending. Try again later.',
-        });
+        appError = 'The coverage data is still pending. Please try again later.';
       }
-      this.setState({ coverage });
+      if (!coverage.show) {
+        appError = 'The coverage backend has had an internal error.';
+      }
+      this.setState({ appError, coverage });
     } catch (error) {
       console.error(error);
       this.setState({
@@ -94,10 +98,17 @@ export default class DiffViewerContainer extends Component {
 
   render() {
     const {
-      appError, changeset, coverage, parsedDiff, supportedExtensions,
+      appError,
+      changeset,
+      coverage,
+      parsedDiff,
+      supportedExtensions,
     } = this.state;
-    const onlySupportedExtensions = filterUnsupportedExtensions(parsedDiff, supportedExtensions);
-    const sortedDiff = sortByPercent(onlySupportedExtensions, coverage);
+    let sortedDiff = [];
+    if (coverage && coverage.show) {
+      const onlySupportedExtensions = filterUnsupportedExtensions(parsedDiff, supportedExtensions);
+      sortedDiff = sortByPercent(onlySupportedExtensions, coverage);
+    }
 
     return (
       <DiffViewer


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/187)
<!-- Reviewable:end -->

This PR fixes issue #135 which means it does not touch the main view but the diff viewer.

It seems that some of the recent changes landed has made this issue not as bad.

There's still a slight difference in behaviour:
* https://firefox-code-coverage.herokuapp.com/#/changeset/3cee5c02db0a065f081989d3e0514563aac355ab
* https://firefox-code-coverage-pr-187.herokuapp.com/#/changeset/3cee5c02db0a065f081989d3e0514563aac355ab

﻿﻿﻿The console, however, it is clean for the 2nd link.

![image](https://user-images.githubusercontent.com/44410/41039414-5c1c9bb8-6967-11e8-946d-9f394ebb28e9.png)
