### PR TITLE
File viewer: Support 'hashchange' navigation events

### DIFF
--- a/src/containers/fileViewer.jsx
+++ b/src/containers/fileViewer.jsx
@@ -18,8 +18,20 @@ export default class FileViewerContainer extends Component {
   }
 
   componentDidMount() {
-    const { revision, path } = this.state;
-    this.fetchData(revision, path);
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location.search === prevProps.location.search) {
+      return;
+    }
+    // Reset the state and fetch new data
+    const newState = this.parseQueryParams();
+    newState.coverage = undefined;
+    newState.parsedFile = undefined;
+    // eslint-disable-next-line react/no-did-update-set-state
+    this.setState(newState);
+    this.fetchData();
   }
 
   setSelectedLine(selectedLineNumber) {
@@ -31,7 +43,8 @@ export default class FileViewerContainer extends Component {
     }
   }
 
-  fetchData(revision, path, repoPath = 'mozilla-central') {
+  fetchData(repoPath = 'mozilla-central') {
+    const { revision, path } = this.state;
     // Get source code from hg
     const fileSource = async () => {
       this.setState({ parsedFile: (await rawFile(revision, path, repoPath)) });


### PR DESCRIPTION
## STR

1. `git clone https://github.com/mozilla/firefox-code-coverage-frontend/ front && cd front`
2. `yarn install && yarn start`
3. Visit http://localhost:5000/#/file?revision=980d4dc65afc&path=mfbt/Assertions.cpp
4. Edit URL to http://localhost:5000/#/file?revision=980d4dc65afc&path=mfbt/ChaosMode.cpp and hit `Enter`

## Expected result

- The page should load + show the coverage data of `ChaosMode.cpp`

## Actual result

- Nothing happens (you need to hit `Cmd + R` to force a page reload and get the correct data)

## The fix

This pull request fixes this by resetting the state when getting a `'hashchange'` event.

@armenzg please take a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/195)
<!-- Reviewable:end -->
