### PR TITLE
Issue #144: Added re-throwing of errors

### DIFF
--- a/src/components/diffLine.jsx
+++ b/src/components/diffLine.jsx
@@ -19,8 +19,8 @@ const DiffLine = ({ change, fileDiffs, id }) => {
           rowClass = 'nolinechange';
         }
       } catch (e) {
-        console.log(e);
         rowClass = 'miss';
+        throw e;
       }
     }
     newLineNumber = c.ln;

--- a/src/containers/diffViewer.jsx
+++ b/src/containers/diffViewer.jsx
@@ -64,10 +64,10 @@ export default class DiffViewerContainer extends Component {
       }
       this.setState({ appError, coverage });
     } catch (error) {
-      console.error(error);
       this.setState({
         appError: 'There was an error fetching the code coverage data.',
       });
+      throw error;
     }
   }
 

--- a/src/containers/fileViewer.jsx
+++ b/src/containers/fileViewer.jsx
@@ -67,6 +67,7 @@ export default class FileViewerContainer extends Component {
         });
     } catch (error) {
       this.setState({ appErr: `${error.name}: ${error.message}` });
+      throw error;
     }
   }
 

--- a/src/containers/summary.jsx
+++ b/src/containers/summary.jsx
@@ -61,13 +61,13 @@ export default class SummaryContainer extends Component {
         pollingEnabled: summary.pending > 0,
       });
     } catch (error) {
-      console.error(error);
       this.setState({
         changesets: {},
         changesetsCoverage: {},
         pollingEnabled: false,
         errorMessage: 'We have failed to fetch coverage data.',
       });
+      throw error;
     }
   }
 
@@ -78,6 +78,7 @@ export default class SummaryContainer extends Component {
       this.setState({ changesetsCoverage, pollingEnabled });
     } catch (e) {
       this.setState({ pollingEnabled: false });
+      throw e;
     }
   }
 

--- a/src/utils/coverage.js
+++ b/src/utils/coverage.js
@@ -76,7 +76,7 @@ export const fileRevisionCoverageSummary = (coverage) => {
   s.numUncovLines = s.uncoveredLines.length;
   s.numTotalLines = s.numCovLines + s.numUncovLines;
   s.percentage = (s.numCovLines !== 0 ||
-     s.numUncovLines !== 0) ? ((s.numCovLines / s.numTotalLines) * 100) : undefined;
+    s.numUncovLines !== 0) ? ((s.numCovLines / s.numTotalLines) * 100) : undefined;
   return s;
 };
 
@@ -245,11 +245,10 @@ export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
       format: 'list',
     });
     if (res.status !== 200) {
-      throw new Error();
+      throw new Error(`HTTP response ${res.status}`);
     }
     return res.json();
   } catch (e) {
-    console.error(`Failed to fetch data for revision: ${revision}, path: ${path}\n${e}`);
-    throw e;
+    throw new Error(`Failed to fetch data for revision: ${revision}, path: ${path}\n${e}`);
   }
 };

--- a/src/utils/hg.js
+++ b/src/utils/hg.js
@@ -53,12 +53,11 @@ export const rawFile = async (node, filePath, repoName = REPO_NAME) => {
   try {
     const res = await getRawFile(node, filePath, repoName);
     if (res.status !== 200) {
-      throw new Error();
+      throw new Error(`HTTP response ${res.status}`);
     }
     return (await res.text()).split('\n');
   } catch (e) {
-    console.error(`Failed to fetch source for revision: ${node}, filePath: ${filePath}\n${e}`);
-    throw new Error('Failed to get source code from hg');
+    throw new Error(`Failed to fetch source for revision: ${node}, filePath: ${filePath}\n${e}`);
   }
 };
 


### PR DESCRIPTION
Fix for #144 

- Removed logging to console
- Added generic `throw error` for catch blocks 


@armenzg please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/196)
<!-- Reviewable:end -->
