### PR TITLE
Refactor FileViewerContainer.parseQueryParameters() away

### DIFF
--- a/src/components/routes.jsx
+++ b/src/components/routes.jsx
@@ -1,3 +1,4 @@
+import { parse } from 'query-string';
 import { Route } from 'react-router-dom';
 
 import AppDisclaimer from './disclaimer';
@@ -28,7 +29,18 @@ const Routes = () => (
     />
     <Route
       path="/file"
-      component={FileViewerContainer}
+      render={({ location }) => {
+        const { path = '', revision } = parse(location.search);
+        // Remove beginning '/' in the path parameter to fetch from source,
+        // makes both path=/path AND path=path acceptable in the URL query
+        // Ex. "path=/accessible/atk/Platform.cpp" AND "path=accessible/atk/Platform.cpp"
+        return (
+          <FileViewerContainer
+            revision={revision}
+            path={path.startsWith('/') ? path.slice(1) : path}
+          />
+        );
+      }}
     />
     <Route
       path="/clear-cache"

--- a/src/utils/coverage.js
+++ b/src/utils/coverage.js
@@ -237,8 +237,8 @@ export const fileRevisionWithActiveData = async (revision, path, repoPath) => {
       where: {
         and: [
           { eq: { 'source.file.name': path } },
-          { prefix: { 'repo.changeset.id': revision } },
           { eq: { 'repo.branch.name': repoPath } },
+          { prefix: { 'repo.changeset.id': revision } },
         ],
       },
       limit: 1000,


### PR DESCRIPTION
... by moving `revision` and `path` from state to props.

This is based on @armenzg's suggestion:

https://github.com/mozilla/firefox-code-coverage-frontend/pull/195#pullrequestreview-134378222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-code-coverage-frontend/215)
<!-- Reviewable:end -->
